### PR TITLE
Read additional sharp constructor options from SHARP_OPTIONS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ const processor = new IIIF.Processor(url, streamResolver, opts);
       the resulting image in software that calculates a default print size based on the height, width, and density
   * `pathPrefix` (string) – the default prefix that precedes the `id` part of the URL path (default: `/iiif/2/`)
 
+### Environment
+If the environment variable `SHARP_OPTIONS` is defined, it will be parsed as JSON and applied to the [constructor](https://sharp.pixelplumbing.com/api-constructor) of the `sharp` image processor.
+
 ## Examples
 
 ### Full Self-Contained Application
@@ -126,9 +129,9 @@ For instance, for the request:
 
 The `id` parameter is `42562145-0998-4b67-bab0-6028328f8319.png` and the `baseUrl` is `https://example.org/iiif/assets`.
 
-### Breaking Changes
+## Breaking Changes
 
-#### v1 -> v2
+### v1 -> v2
 
 * The `id` parameter passed to the [stream resolver](#stream-resolver) and [dimensions callback](#dimension-function) was
   changed from a `string` to an `object` containing the `id` and `baseUrl`.
@@ -147,14 +150,16 @@ The `id` parameter is `42562145-0998-4b67-bab0-6028328f8319.png` and the `baseUr
 
   See [issue #19](https://github.com/samvera/node-iiif/issues/19) for context on why this change was made.
 
-### Contributing
+## Contributing
 
 Contributions are welcome in the form of bug reports, suggestions, pull requests, and/or documentation.
 
 If you're working on a PR for this project, create a feature branch off of `main`.
 
+This project uses the [debug](https://www.npmjs.com/package/debug) library for selective debugging output. To view all IIIF-related debug messages, set the environment variable `DEBUG=iiif-processor:*`. To view just the main or transformer contexts, set `DEBUG=iiif-processor:main` or `DEBUG=iiif-processor:transform`.
+
 This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) and [language recommendations](https://github.com/samvera/maintenance/blob/main/templates/CONTRIBUTING.md#language).  Please ***do not*** create a branch called `master` for this repository or as part of your pull request; the branch will either need to be removed or renamed before it can be considered for inclusion in the code base and history of this repository.
 
-### License
+## License
 
 `node-iiif` is available under [the Apache 2.0 license](LICENSE).

--- a/examples/tiny-iiif/package.json
+++ b/examples/tiny-iiif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-iiif",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Example server for node-iiif using @tinyhttp",
   "type": "module",
   "main": "index.js",

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,5 +1,6 @@
 const Sharp = require('sharp');
 const IIIFError = require('./error');
+const debug = require('debug')('iiif-processor:transform');
 
 // Integer RegEx
 const IR = '\\d+';
@@ -14,6 +15,16 @@ const Validators = {
   rotation: `\\!?${FR}`
 };
 
+function sharpOptions () {
+  let result;
+  try {
+    result = JSON.parse(process.env.SHARP_OPTIONS || '{}');
+  } catch {
+    result = {};
+  }
+  return result;
+}
+
 function validator (type) {
   let result = Validators[type];
   if (result instanceof Array) {
@@ -23,6 +34,7 @@ function validator (type) {
 }
 
 function validate (type, v) {
+  debug('validating %s %s', type, v);
   const re = new RegExp(`^${validator(type)}$`);
   if (!re.test(v)) {
     throw new IIIFError(`Invalid ${type}: ${v}`);
@@ -31,6 +43,7 @@ function validate (type, v) {
 }
 
 function validateDensity (v) {
+  debug('validating density %s', v);
   if (v === null) return true;
   if (v === undefined) return true;
   if (typeof v !== 'number' || v < 0) {
@@ -50,7 +63,9 @@ function iiifRegExp () {
 class Operations {
   constructor (dims) {
     this.dims = dims;
-    this.pipeline = Sharp({ limitInputPixels: false });
+    const opts = { limitInputPixels: false, ...sharpOptions() };
+    debug('Creating sharp pipeline using %j', opts);
+    this.pipeline = Sharp(opts);
   }
 
   region (v) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iiif-processor",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "IIIF 2.1 Image API modules for NodeJS",
   "main": "index.js",
   "repository": "https://github.com/samvera/node-iiif",
@@ -19,6 +19,7 @@
     "vips"
   ],
   "dependencies": {
+    "debug": "^4.3.4",
     "mime-types": "2.x",
     "probe-image-size": "github:notch8/probe-image-size#master",
     "sharp": ">=0.25.2 <1.0.0"

--- a/tests/transform.test.js
+++ b/tests/transform.test.js
@@ -8,6 +8,35 @@ const { qualities, formats, regions, sizes, rotations } = require('./fixtures/ii
 
 let subject;
 
+describe('environment options', () => {
+  afterEach(() => {
+    delete process.env.SHARP_OPTIONS;
+  });
+
+  it('uses the correct defaults', () => {
+    subject = new Transform.Operations({ width: 1024, height: 768 });
+    assert.equal(subject.pipeline.options.input.limitInputPixels, 0);
+    assert.equal(subject.pipeline.options.input.sequentialRead, false);
+    assert.equal(subject.pipeline.options.input.unlimited, false);
+  });
+
+  it("correctly reads SHARP_OPTIONS", () => {
+    process.env.SHARP_OPTIONS = '{"sequentialRead":true}';
+    subject = new Transform.Operations({ width: 1024, height: 768 });
+    assert.equal(subject.pipeline.options.input.limitInputPixels, 0);
+    assert.equal(subject.pipeline.options.input.sequentialRead, true);
+    assert.equal(subject.pipeline.options.input.unlimited, false);
+  });
+
+  it("ignores bad JSON", () => {
+    process.env.SHARP_OPTIONS = '{ this is not json';
+    subject = new Transform.Operations({ width: 1024, height: 768 });
+    assert.equal(subject.pipeline.options.input.limitInputPixels, 0);
+    assert.equal(subject.pipeline.options.input.sequentialRead, false);
+    assert.equal(subject.pipeline.options.input.unlimited, false);
+  });
+});
+
 describe('transformer', () => {
   beforeEach(() => {
     subject = new Transform.Operations({ width: 1024, height: 768 });


### PR DESCRIPTION
This is to allow quick iteration and experimentation with different Sharp settings in `serverless-iiif`. For example, I've found using [tiny-iiif](https://github.com/samvera/node-iiif/tree/main/examples/tiny-iiif) that some of our images process _much_ faster using the `sequentialRead: true` option. This change would allow those settings to be tried out without changing default behavior or the external interface/API at all.

Also adds `debug` package for selective debug output