### PR TITLE
Fix calculator#fullSize()

### DIFF
--- a/examples/tiny-iiif/package.json
+++ b/examples/tiny-iiif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-iiif",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Example server for node-iiif using @tinyhttp",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iiif-processor",
-  "version": "4.0.4",
+  "version": "4.0.5-rc.0",
   "description": "IIIF 2.1 & 3.0 Image API modules for NodeJS",
   "main": "./src",
   "repository": "https://github.com/samvera/node-iiif",

--- a/tests/v2/calculator.test.js
+++ b/tests/v2/calculator.test.js
@@ -71,7 +71,7 @@ describe('Calculator', () => {
     assert.throws(() => subject.rotation('badValue'), IIIFError);
   });
 
-  it('info', () => {
+  it('info with pct:region', () => {
     const expected = {
       region: { left: 512, top: 384, width: 256, height: 192 },
       size: { fit: 'cover', width: 512, height: 384 },
@@ -83,6 +83,21 @@ describe('Calculator', () => {
     };
 
     subject.region("pct:50,50,25,25").size("512,384").rotation("45").quality("default").format("jpg", 600);
+    assert.deepEqual(subject.info(), expected);
+  });
+
+  it('info with pixel region', () => {
+    const expected = {
+      region: { left: 1014, top: 512, width: 10, height: 256 },
+      size: { fit: 'cover', width: 5, height: null },
+      rotation: { flop: false, degree: 0 },
+      quality: 'default',
+      format: { type: 'jpg', density: 600 },
+      fullSize: { width: 512, height: 384 },
+      upscale: true
+    };
+
+    subject.region("1014,512,10,256").size("5,").rotation("0").quality("default").format("jpg", 600);
     assert.deepEqual(subject.info(), expected);
   });
 });

--- a/tests/v2/integration.test.js
+++ b/tests/v2/integration.test.js
@@ -120,8 +120,8 @@ describe('IIIF transformation', () => {
     
     assert(result.canonicalLink);
     assert(result.profileLink);
-    assert.strictEqual(size.width, 24);
-    assert.strictEqual(size.height, 24);
+    assert.strictEqual(size.width, 25);
+    assert.strictEqual(size.height, 25);
     assert.strictEqual(size.format, 'png');
   });
 });
@@ -141,8 +141,8 @@ describe('Two-argument streamResolver', () => {
     const result = await subject.execute();
     const size = await Sharp(result.body).metadata();
 
-    assert.strictEqual(size.width, 24);
-    assert.strictEqual(size.height, 24);
+    assert.strictEqual(size.width, 25);
+    assert.strictEqual(size.height, 25);
     assert.strictEqual(size.format, 'png');
   });
 });

--- a/tests/v2/processor.test.js
+++ b/tests/v2/processor.test.js
@@ -217,7 +217,7 @@ describe('dimension function', () => {
     const dimensionFunction = ({ id, baseUrl }) => {
       expect(id).toEqual('i');
       expect(baseUrl).toEqual('https://example.org/iiif/2/ab/cd/ef/gh/');
-      return { w: 100, h: 100 }
+      return { width: 100, height: 100 }
     }
 
     const subject = new Processor( 

--- a/tests/v3/calculator.test.js
+++ b/tests/v3/calculator.test.js
@@ -100,7 +100,7 @@ describe('Calculator', () => {
         rotation: { flop: false, degree: 45 },
         quality: 'default',
         format: { type: 'jpg', density: 600 },
-        fullSize: { width: 1364, height: 1024 },
+        fullSize: { width: 1364, height: 1023 },
         upscale: true
       };
 

--- a/tests/v3/integration.test.js
+++ b/tests/v3/integration.test.js
@@ -118,8 +118,8 @@ describe('IIIF transformation', () => {
     const result = await subject.execute();
     const size = await Sharp(result.body).metadata();
     
-    assert.strictEqual(size.width, 24);
-    assert.strictEqual(size.height, 24);
+    assert.strictEqual(size.width, 25);
+    assert.strictEqual(size.height, 25);
     assert.strictEqual(size.format, 'png');
   });
 });
@@ -139,8 +139,8 @@ describe('Two-argument streamResolver', () => {
     const result = await subject.execute();
     const size = await Sharp(result.body).metadata();
 
-    assert.strictEqual(size.width, 24);
-    assert.strictEqual(size.height, 24);
+    assert.strictEqual(size.width, 25);
+    assert.strictEqual(size.height, 25);
     assert.strictEqual(size.format, 'png');
   });
 });

--- a/tests/v3/processor.test.js
+++ b/tests/v3/processor.test.js
@@ -213,7 +213,7 @@ describe('dimension function', () => {
     const dimensionFunction = ({ id, baseUrl }) => {
       expect(id).toEqual('i');
       expect(baseUrl).toEqual('https://example.org/iiif/3/ab/cd/ef/gh/');
-      return { w: 100, h: 100 }
+      return { width: 100, height: 100 }
     }
 
     const subject = new Processor(


### PR DESCRIPTION
There was a bug in `calculator/base.js` (essentially based on me trying to be too clever with size calculations) that was causing errors when using absolute pixel values for region cropping. This version fixes that calculation, and updates a few test expectations based on changes in rounding as a result. I've already pushed it to NPM as `v4.0.5-rc.0` to make it easier to test with `serverless-iiif`.
