### PR TITLE
Update to sharp v0.33.x and make it an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Only features and major fixes are listed. Everything else can be considered a minor bugfix or maintenance release.
 
+##### v5.0.0
+- Export `Calculator`
+- Make `sharp` an optional dependency for those who just want to use `Calculator`
+
 ##### v4.0.0
 - Add support for [IIIF Image API v3.0.0](https://iiif.io/api/image/3.0/) alongside support for [v2.1.1](https://iiif.io/api/image/2.1/)
 - Add `canonicalLink` and `profileLink` properties to the response to support the respective link header features (see [example](./examples/tiny-iiif/iiif.js#L28) of how to use this)

--- a/examples/tiny-iiif/package.json
+++ b/examples/tiny-iiif/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@tinyhttp/app": "^2.0.25",
     "@tinyhttp/logger": "^1.3.0",
-    "iiif-processor": "../.."
+    "iiif-processor": "../..",
+    "sharp": "^0.33.5"
   },
   "devDependencies": {
     "eslint": "^7.10.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "mime-types": "2.x",
-    "sharp": ">=0.25.2 <0.33.0"
+    "sharp": "^0.33.0"
   },
   "devDependencies": {
     "coveralls": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iiif-processor",
-  "version": "4.0.7",
+  "version": "5.0.0",
   "description": "IIIF 2.1 & 3.0 Image API modules for NodeJS",
   "main": "./src",
   "repository": "https://github.com/samvera/node-iiif",
@@ -28,8 +28,7 @@
   ],
   "dependencies": {
     "debug": "^4.3.4",
-    "mime-types": "2.x",
-    "sharp": "^0.33.0"
+    "mime-types": "2.x"
   },
   "devDependencies": {
     "coveralls": "^3.1.1",
@@ -40,6 +39,9 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.4.3"
+  },
+  "optionalDependencies": {
+    "sharp": "^0.33.5"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/transform.js
+++ b/src/transform.js
@@ -141,7 +141,7 @@ class Operations {
   }
 
   withMetadata (v) {
-    if (v) this.#pipeline = this.#pipeline.withMetadata();
+    if (v) this.#pipeline = this.#pipeline.keepMetadata();
     return this;
   }
 

--- a/tests/v2/processor.test.js
+++ b/tests/v2/processor.test.js
@@ -37,7 +37,7 @@ describe('IIIF Processor', () => {
     assert.strictEqual(opts.heightPre, 40);
     assert.strictEqual(opts.formatOut, 'png');
     assert.strictEqual(opts.canvas, 'crop');
-    assert.strictEqual(opts.withMetadata, false);
+    assert.strictEqual(opts.keepMetadata, 0);
   });
 });
 
@@ -75,7 +75,7 @@ describe('Include metadata', () => {
     const pipe = await subject.operations(dims).pipeline();
     const opts = pipe.options;
 
-    assert.strictEqual(opts.withMetadata, true);
+    assert.notEqual(opts.keepMetadata, 0);
   });
 });
 

--- a/tests/v3/processor.test.js
+++ b/tests/v3/processor.test.js
@@ -37,7 +37,7 @@ describe('IIIF Processor', () => {
     assert.strictEqual(opts.heightPre, 40);
     assert.strictEqual(opts.formatOut, 'png');
     assert.strictEqual(opts.canvas, 'crop');
-    assert.strictEqual(opts.withMetadata, false);
+    assert.strictEqual(opts.keepMetadata, 0);
   });
 });
 
@@ -78,7 +78,7 @@ describe('Include metadata', () => {
     const pipe = await subject.operations(dims).pipeline();
     const opts = pipe.options;
 
-    assert.strictEqual(opts.withMetadata, true);
+    assert.notEqual(opts.keepMetadata, 0);
   });
 });
 


### PR DESCRIPTION
Most users of `iiif-processor` will want to use it with `sharp` for image processing, but others may just want to use it for the `Calculator` class. This PR makes it possible to omit the `sharp` install for a smaller build when only the calculator is needed.