### PR TITLE
Add TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "iiif-processor",
   "version": "5.0.0",
   "description": "IIIF 2.1 & 3.0 Image API modules for NodeJS",
-  "main": "./src",
+  "main": "src/index.js",
+  "types": "types/index.d.ts",
   "repository": "https://github.com/samvera/node-iiif",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
@@ -10,6 +11,7 @@
     "CHANGELOG.md",
     "CONTRIBUTING.md",
     "src/**/*.js",
+    "types/**/*.d.ts",
     "LICENSE",
     "package.json",
     "README.md"

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-sparse-arrays */
-module.exports = [,,
-  require('./v2'),
-  require('./v3')
-];
+module.exports = {
+  2: require('./v2'),
+  3: require('./v3')
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "typeRoots": ["types"]
+  },
+  "include": ["src/**/*.js"]
+}

--- a/types/calculator.d.ts
+++ b/types/calculator.d.ts
@@ -1,0 +1,39 @@
+import { BoundingBox, Dimensions, MaxDimensions, Quality, Format } from './types';
+
+export type CalculatedImageSize = {
+  region: BoundingBox;
+  size: Dimensions;
+  rotation: { flop: boolean; degree: number };
+  quality: Quality;
+  format: { type: Format };
+  upscale: boolean;
+  fullSize: Dimensions;
+};
+
+export declare class Calculator {
+  static parsePath(path: string): {
+    id: string,
+    info: string,
+    region: string,
+    size: string,
+    rotation: string,
+    quality: string,
+    format: string
+  }
+
+  constructor(
+    dims: Dimensions,
+    opts?: {
+      max?: MaxDimensions
+    }
+  );
+
+  region(v: string): Calculator;
+  size(v: string): Calculator;
+  rotation(v: string): Calculator;
+  quality(v: Quality): Calculator;
+  format(v: Format, density: number): Calculator;
+
+  info(): CalculatedImageSize;
+  canonicalPath(): string;
+}

--- a/types/error.d.ts
+++ b/types/error.d.ts
@@ -1,0 +1,10 @@
+export declare class IIIFError extends Error {
+  statusCode: number
+  
+  constructor(
+    message: string,
+    opts: {
+      statusCode?: number
+    }
+  )
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,34 @@
+import { Dimensions, MaxDimensions } from './types';
+import { Calculator } from './calculator';
+
+interface IIIFVersion {
+  infoDoc: (params: {
+    id: string;
+    width: number;
+    height: number;
+    sizes: Array<Dimensions>;
+    max?: MaxDimensions;
+  }) => any;
+
+  profileLink: string;
+  Calculator: typeof Calculator;
+  Qualities: string[];
+  Formats: string[];
+}
+
+type IIIFVersions = Record<string, IIIFVersion>;
+
+export declare class IIIFError extends Error {
+  statusCode: number;
+
+  constructor(
+    message: string,
+    opts: {
+      statusCode?: number;
+    }
+  );
+}
+
+export { Processor } from './processor';
+
+export declare const Versions: IIIFVersions;

--- a/types/processor.d.ts
+++ b/types/processor.d.ts
@@ -18,7 +18,7 @@ export type DimensionFunction = (
 
 export type StreamResolver = (
   input: { id: string, baseUrl: string },
-  callback?: (result: NodeJS.ReadableStream) => any
+  callback?: (result: NodeJS.ReadableStream) => Promise<unknown>
 ) => Promise<NodeJS.ReadableStream>;
 
 export declare class Processor {
@@ -31,7 +31,7 @@ export declare class Processor {
       includeMetadata?: boolean;
       density?: number;
       pathPrefix?: string;
-      version?: 2 | 3;
+      iiifVersion?: 2 | 3;
     }
   );
 

--- a/types/processor.d.ts
+++ b/types/processor.d.ts
@@ -12,19 +12,28 @@ export type InfoJson = {
   body: string;
 };
 
+export type DimensionFunction = (
+  input: { id: string, baseUrl: string }
+) => Promise<Dimensions | Array<Dimensions>>;
+
+export type StreamResolver = (
+  input: { id: string, baseUrl: string },
+  callback?: (result: NodeJS.ReadableStream) => any
+) => Promise<NodeJS.ReadableStream>;
+
 export declare class Processor {
   constructor(
     url: string,
-    streamResolver: (id: string) => NodeJS.ReadableStream,
+    streamResolver: StreamResolver,
     opts?: {
-      dimensionFunction?: (id: string) => Dimensions | Array<Dimensions>,
-      max?: MaxDimensions,
-      includeMetadata?: boolean,
-      density?: number,
-      pathPrefix?: string,
-      version?: 2|3
+      dimensionFunction?: DimensionFunction;
+      max?: MaxDimensions;
+      includeMetadata?: boolean;
+      density?: number;
+      pathPrefix?: string;
+      version?: 2 | 3;
     }
   );
 
-  execute(): InfoJson | IiifImage;
+  execute(): Promise<InfoJson | IiifImage>;
 }

--- a/types/processor.d.ts
+++ b/types/processor.d.ts
@@ -1,0 +1,30 @@
+import { Dimensions, MaxDimensions } from './types';
+
+export type IiifImage = {
+  canonicalLink: string;
+  profileLink: string;
+  contentType: string;
+  body: Buffer;
+};
+
+export type InfoJson = {
+  contentType: 'application/json';
+  body: string;
+};
+
+export declare class Processor {
+  constructor(
+    url: string,
+    streamResolver: (id: string) => NodeJS.ReadableStream,
+    opts?: {
+      dimensionFunction?: (id: string) => Dimensions | Array<Dimensions>,
+      max?: MaxDimensions,
+      includeMetadata?: boolean,
+      density?: number,
+      pathPrefix?: string,
+      version?: 2|3
+    }
+  );
+
+  execute(): InfoJson | IiifImage;
+}

--- a/types/processor.d.ts
+++ b/types/processor.d.ts
@@ -17,14 +17,18 @@ export type DimensionFunction = (
 ) => Promise<Dimensions | Array<Dimensions>>;
 
 export type StreamResolver = (
-  input: { id: string, baseUrl: string },
-  callback?: (result: NodeJS.ReadableStream) => Promise<unknown>
+  input: { id: string, baseUrl: string }
 ) => Promise<NodeJS.ReadableStream>;
+
+export type StreamResolverWithCallback = (
+  input: { id: string, baseUrl: string },
+  callback: (result: NodeJS.ReadableStream) => Promise<unknown>
+) => Promise<unknown>;
 
 export declare class Processor {
   constructor(
     url: string,
-    streamResolver: StreamResolver,
+    streamResolver: StreamResolver | StreamResolverWithCallback,
     opts?: {
       dimensionFunction?: DimensionFunction;
       max?: MaxDimensions;

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,0 +1,21 @@
+export type BoundingBox = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export type Dimensions = {
+  width: number;
+  height: number;
+};
+
+export type Format = 'jpg' | 'jpeg' | 'tif' | 'tiff' | 'png' | 'webp';
+
+export type MaxDimensions = {
+  width?: number;
+  height?: number;
+  area?: number;
+};
+
+export type Quality = 'color' | 'gray' | 'bitonal' | 'default';


### PR DESCRIPTION
Adds a `/types` directory and the appropriate `tsconfig.json` and `package.json` entries to let compilers and language servers know where to find them.

Resolves #35