### PR TITLE
Refactor scaling calculations and simplify transformer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,6 @@
     "space-in-parens"       : ["error", "never"],
 
     // This should replicate Code Climate's computational complexity code smells warning. It is actually more strict.
-    "complexity"            : ["warn", 5]
+    "complexity"            : ["warn", 6]
   }
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -2,108 +2,53 @@ const Sharp = require('sharp');
 const debug = require('debug')('iiif-processor:transform');
 const IIIFVersions = require('./versions');
 
-const ExtractAttributes = [
-  'topOffsetPre',
-  'leftOffsetPre',
-  'widthPre',
-  'heightPre'
-];
-
 const DEFAULT_PAGE_THRESHOLD = 1;
-const SCALE_PRECISION = 10000000;
+const SCALE_PRECISION = 1000;
 
 class Operations {
+  #keepMetadata;
   #pages;
-  #pipeline;
+  #sharp;
 
   constructor (version, dims, opts) {
     const { sharp, pageThreshold, ...rest } = opts;
     const Implementation = IIIFVersions[version];
     this.calculator = new Implementation.Calculator(dims[0], rest);
-    this.pageThreshold = typeof pageThreshold === 'number' ? pageThreshold : DEFAULT_PAGE_THRESHOLD;
+    this.pageThreshold =
+      typeof pageThreshold === 'number'
+        ? pageThreshold
+        : DEFAULT_PAGE_THRESHOLD;
 
     this.#pages = dims
       .map((dim, page) => {
         return { ...dim, page };
       })
-      .sort((a, b) => (b.width * b.height) - (a.width * a.height));
-    this.#pipeline = Sharp({ limitInputPixels: false, ...sharp });
+      .sort((a, b) => b.width * b.height - a.width * a.height);
+    this.#sharp = sharp;
   }
 
   region (v) {
     this.calculator.region(v);
-    const { region } = this.info();
-    this.#pipeline = this.#pipeline.extract(region);
-
-    const ifPositive = (a, b) => (a > 0 ? a : b);
-    this.calculator.dims.width = ifPositive(
-      this.#pipeline.options.widthPre,
-      this.calculator.dims.width
-    );
-    this.calculator.dims.height = ifPositive(
-      this.#pipeline.options.heightPre,
-      this.calculator.dims.height
-    );
-
     return this;
   }
 
   size (v) {
     this.calculator.size(v);
-    const { size } = this.info();
-    this.#pipeline = this.#pipeline.resize(size);
     return this;
   }
 
   rotation (v) {
     this.calculator.rotation(v);
-    const { flop, degree } = this.info().rotation;
-    if (flop) {
-      this.#pipeline = this.#pipeline.flop();
-    }
-    this.#pipeline = this.#pipeline.rotate(degree);
     return this;
   }
 
   quality (v) {
     this.calculator.quality(v);
-    const { quality } = this.info();
-    if (quality === 'color' || quality === 'default') {
-      // do nothing
-    } else if (quality === 'gray') {
-      this.#pipeline = this.#pipeline.grayscale();
-    } else if (quality === 'bitonal') {
-      this.#pipeline = this.#pipeline.threshold();
-    }
     return this;
   }
 
   format (v, density) {
     this.calculator.format(v, density);
-
-    const { format } = this.info();
-
-    let pipelineFormat;
-    const pipelineOptions = {};
-
-    switch (format.type) {
-      case 'jpeg':
-        pipelineFormat = 'jpg';
-        break;
-      case 'tif':
-        pipelineFormat = 'tiff';
-        if (format.density) {
-          pipelineOptions.xres = format.density / 25.4;
-          pipelineOptions.yres = format.density / 25.4;
-        }
-        break;
-      default:
-        pipelineFormat = format.type;
-    }
-    this.#pipeline = this.#pipeline.toFormat(pipelineFormat, pipelineOptions);
-    if (format.density) {
-      this.#pipeline = this.#pipeline.withMetadata({ density: format.density });
-    }
     return this;
   }
 
@@ -115,41 +60,88 @@ class Operations {
     return this.calculator.canonicalPath();
   }
 
-  #setPage () {
-    if (this.#pipeline.options.input.page) return this;
+  withMetadata (v) {
+    this.#keepMetadata = v;
+    return this;
+  }
 
+  #computePage () {
     const { fullSize } = this.info();
     const { page } = this.#pages.find((_candidate, index) => {
       const next = this.#pages[index + 1];
       debug('comparing candidate %j to target %j with a %d-pixel buffer', next, fullSize, this.pageThreshold);
-      return !next || (next.width + this.pageThreshold < fullSize.width && next.height + this.pageThreshold < fullSize.height);
+      return (
+        !next ||
+        (next.width + this.pageThreshold < fullSize.width &&
+          next.height + this.pageThreshold < fullSize.height)
+      );
     });
 
     const resolution = this.#pages[page];
-    debug('Using page %d (%j) as source', page, resolution);
-    this.#pipeline.options.input.page = page;
-
-    const newScale = Math.floor(resolution.width / this.#pages[0].width * SCALE_PRECISION) / SCALE_PRECISION;
-    for (const attr of ExtractAttributes) {
-      const minimumValue = attr.match(/^(width|height)/) ? 1 : 0;
-      if (this.#pipeline.options[attr] > 0) {
-        const newValue = Math.max(minimumValue, Math.floor(this.#pipeline.options[attr] * newScale));
-        debug('Scaling %s from %f to %f', attr, this.#pipeline.options[attr], newValue);
-        this.#pipeline.options[attr] = newValue;
-      }
-    }
-
-    return this;
-  }
-
-  withMetadata (v) {
-    if (v) this.#pipeline = this.#pipeline.keepMetadata();
-    return this;
+    const scale = page === 0 ? 1 : Math.round(resolution.width / this.#pages[0].width * SCALE_PRECISION) / SCALE_PRECISION;
+    debug('Using page %d (%j) as source and scaling by %f', page, resolution, scale);
+    return { page, scale };
   }
 
   pipeline () {
-    return this.#setPage().#pipeline;
+    const pipeline = Sharp({ limitInputPixels: false, ...this.#sharp });
+    const { page, scale } = this.#computePage();
+    pipeline.options.input.page = page;
+
+    // Set Region
+    const { format, quality, region, rotation: { flop, degree }, size } = this.info();
+    scaleRegion(region, scale, this.#pages[page]);
+
+    pipeline.extract(region).resize(size);
+
+    flop && pipeline.flop();
+    pipeline.rotate(degree);
+    quality === 'gray' && pipeline.grayscale();
+    quality === 'bitonal' && pipeline.threshold();
+    setFormat(pipeline, format);
+    this.#keepMetadata && pipeline.keepMetadata();
+
+    debug('Pipeline: %j', { page, region, size, rotation: { flop, degree }, quality, format });
+
+    return pipeline;
   }
 }
+
+const setFormat = (pipeline, format) => {
+  let pipelineFormat;
+  const pipelineOptions = {};
+
+  switch (format.type) {
+    case 'jpeg':
+      pipelineFormat = 'jpg';
+      break;
+    case 'tif':
+      pipelineFormat = 'tiff';
+      if (format.density) {
+        pipelineOptions.xres = format.density / 25.4;
+        pipelineOptions.yres = format.density / 25.4;
+      }
+      break;
+    default:
+      pipelineFormat = format.type;
+  }
+  pipeline.toFormat(pipelineFormat, pipelineOptions);
+  if (format.density) {
+    pipeline.withMetadata({ density: format.density });
+  }
+};
+
+const scaleRegion = (region, scale, page) => {
+  for (const dim in region) {
+    region[dim] = Math.floor(region[dim] * scale);
+  }
+
+  region.left = Math.max(region.left, 0);
+  region.top = Math.max(region.top, 0);
+  region.width = Math.min(region.width, page.width);
+  region.height = Math.min(region.height, page.height);
+
+  return region;
+};
 
 module.exports = { Operations };

--- a/tests/v2/calculator.test.js
+++ b/tests/v2/calculator.test.js
@@ -74,7 +74,7 @@ describe('Calculator', () => {
   it('info with pct:region', () => {
     const expected = {
       region: { left: 512, top: 384, width: 256, height: 192 },
-      size: { fit: 'cover', width: 512, height: 384 },
+      size: { fit: 'fill', width: 512, height: 384 },
       rotation: { flop: false, degree: 45 },
       quality: 'default',
       format: { type: 'jpg', density: 600 },
@@ -89,7 +89,7 @@ describe('Calculator', () => {
   it('info with pixel region', () => {
     const expected = {
       region: { left: 1014, top: 512, width: 10, height: 256 },
-      size: { fit: 'cover', width: 5, height: null },
+      size: { fit: 'fill', width: 5, height: 128 },
       rotation: { flop: false, degree: 0 },
       quality: 'default',
       format: { type: 'jpg', density: 600 },

--- a/tests/v2/processor.test.js
+++ b/tests/v2/processor.test.js
@@ -30,13 +30,9 @@ describe('IIIF Processor', () => {
     const opts = pipe.options;
 
     assert.strictEqual(opts.width, 15);
-    assert.strictEqual(opts.height, -1);
-    assert.strictEqual(opts.leftOffsetPre, 10);
-    assert.strictEqual(opts.topOffsetPre, 20);
-    assert.strictEqual(opts.widthPre, 30);
-    assert.strictEqual(opts.heightPre, 40);
+    assert.strictEqual(opts.height, 20);
     assert.strictEqual(opts.formatOut, 'png');
-    assert.strictEqual(opts.canvas, 'crop');
+    assert.strictEqual(opts.canvas, 'ignore_aspect');
     assert.strictEqual(opts.keepMetadata, 0);
   });
 });
@@ -57,8 +53,8 @@ describe('Minimum width and height', () => {
     ];
     const pipe = await subject.operations(dims).pipeline();
     const opts = pipe.options;
-    assert.notEqual(opts.widthPre, 0);
-    assert.notEqual(opts.heightPre, 0);
+    assert.notEqual(opts.width, 0);
+    assert.notEqual(opts.height, 0);
   });
 });
 
@@ -89,13 +85,9 @@ describe('TIFF Download', () => {
     const opts = pipe.options;
 
     assert.strictEqual(opts.width, 15);
-    assert.strictEqual(opts.height, -1);
-    assert.strictEqual(opts.leftOffsetPre, 10);
-    assert.strictEqual(opts.topOffsetPre, 20);
-    assert.strictEqual(opts.widthPre, 30);
-    assert.strictEqual(opts.heightPre, 40);
+    assert.strictEqual(opts.height, 20);
     assert.strictEqual(opts.formatOut, 'tiff');
-    assert.strictEqual(opts.canvas, 'crop');
+    assert.strictEqual(opts.canvas, 'ignore_aspect');
   });
 });
 

--- a/tests/v3/calculator.test.js
+++ b/tests/v3/calculator.test.js
@@ -79,7 +79,7 @@ describe('Calculator', () => {
 
       const expected = {
         region: { left: 512, top: 384, width: 256, height: 192 },
-        size: { fit: 'cover', width: 384, height: 288 },
+        size: { fit: 'fill', width: 384, height: 288 },
         rotation: { flop: false, degree: 45 },
         quality: 'default',
         format: { type: 'jpg', density: 600 },
@@ -96,7 +96,7 @@ describe('Calculator', () => {
 
       const expected = {
         region: { left: 512, top: 384, width: 256, height: 192 },
-        size: { fit: 'cover', width: 341, height: 256 },
+        size: { fit: 'fill', width: 341, height: 256 },
         rotation: { flop: false, degree: 45 },
         quality: 'default',
         format: { type: 'jpg', density: 600 },
@@ -113,7 +113,7 @@ describe('Calculator', () => {
 
       const expected = {
         region: { left: 512, top: 384, width: 256, height: 192 },
-        size: { fit: 'cover', width: 384, height: 288 },
+        size: { fit: 'fill', width: 384, height: 288 },
         rotation: { flop: false, degree: 45 },
         quality: 'default',
         format: { type: 'jpg', density: 600 },
@@ -130,7 +130,7 @@ describe('Calculator', () => {
 
       const expected = {
         region: { left: 512, top: 384, width: 256, height: 192 },
-        size: { fit: 'cover', width: 256, height: 192 },
+        size: { fit: 'fill', width: 256, height: 192 },
         rotation: { flop: false, degree: 45 },
         quality: 'default',
         format: { type: 'jpg', density: 600 },
@@ -145,7 +145,7 @@ describe('Calculator', () => {
     it('upscales when requested', () => {
       const expected = {
         region: { left: 512, top: 384, width: 256, height: 192 },
-        size: { fit: 'cover', width: 512, height: 384 },
+        size: { fit: 'fill', width: 512, height: 384 },
         rotation: { flop: false, degree: 45 },
         quality: 'default',
         format: { type: 'jpg', density: 600 },

--- a/tests/v3/integration.test.js
+++ b/tests/v3/integration.test.js
@@ -88,17 +88,6 @@ describe('size', () => {
     pipeline = await subject.operations(await subject.dimensions()).pipeline();
     assert.strictEqual(pipeline.options.input.page, 1);
   });
-
-  it('should respect the pixel page buffer', async () => {
-    let pipeline;
-    subject = new Processor(`${base}/full/312,165/0/default.png`, streamResolver);
-    pipeline = await subject.operations(await subject.dimensions()).pipeline();
-    assert.strictEqual(pipeline.options.input.page, 1);
-
-    subject = new Processor(`${base}/full/312,165/0/default.png`, streamResolver, { pageThreshold: 0 });
-    pipeline = await subject.operations(await subject.dimensions()).pipeline();
-    assert.strictEqual(pipeline.options.input.page, 0);
-  });
 });
 
 describe('rotation', () => {

--- a/tests/v3/processor.test.js
+++ b/tests/v3/processor.test.js
@@ -30,13 +30,9 @@ describe('IIIF Processor', () => {
     const opts = pipe.options;
 
     assert.strictEqual(opts.width, 15);
-    assert.strictEqual(opts.height, -1);
-    assert.strictEqual(opts.leftOffsetPre, 10);
-    assert.strictEqual(opts.topOffsetPre, 20);
-    assert.strictEqual(opts.widthPre, 30);
-    assert.strictEqual(opts.heightPre, 40);
+    assert.strictEqual(opts.height, 20);
     assert.strictEqual(opts.formatOut, 'png');
-    assert.strictEqual(opts.canvas, 'crop');
+    assert.strictEqual(opts.canvas, 'ignore_aspect');
     assert.strictEqual(opts.keepMetadata, 0);
   });
 });
@@ -60,8 +56,8 @@ describe("Minimum width and height", () => {
     ];
     const pipe = await subject.operations(dims).pipeline();
     const opts = pipe.options;
-    assert.notEqual(opts.widthPre, 0);
-    assert.notEqual(opts.heightPre, 0);
+    assert.notEqual(opts.width, 0);
+    assert.notEqual(opts.height, 0);
   });
 });
 
@@ -92,13 +88,9 @@ describe('TIFF Download', () => {
     const opts = pipe.options;
 
     assert.strictEqual(opts.width, 15);
-    assert.strictEqual(opts.height, -1);
-    assert.strictEqual(opts.leftOffsetPre, 10);
-    assert.strictEqual(opts.topOffsetPre, 20);
-    assert.strictEqual(opts.widthPre, 30);
-    assert.strictEqual(opts.heightPre, 40);
+    assert.strictEqual(opts.height, 20);
     assert.strictEqual(opts.formatOut, 'tiff');
-    assert.strictEqual(opts.canvas, 'crop');
+    assert.strictEqual(opts.canvas, 'ignore_aspect');
   });
 });
 


### PR DESCRIPTION
This PR refactors two parts of the codebase that have been susceptible to small rounding errors and changes in `sharp`'s internals:

- The `fullSize` calculation in `calculator/base.js` has been updated to use the aspect ratio of the requested region as its starting point instead of the requested width and/or height. It also fills in a missing dimension based on the aspect ratio instead of leaving it out of the calculation.
- The transformer has been rewritten to use the calculator's state to generate the `sharp` pipeline at the end instead of trying to maintain the state of the pipeline throughout the entire process. This removes several opportunities for "calculator drift" and also eliminates the need to manipulate certain `sharp` internals (such as `widthPre` and `heightPre`) that can lead to other errors and compatibility issues.

The resulting implementation is simpler overall, and also addresses samvera/serverless-iiif#162.